### PR TITLE
Polish site styling and remove bubble column guides

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     body {
       margin: 0;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background-color: #b3e0ff;
+      background: linear-gradient(to bottom, #e0f4ff, #b3e0ff);
       overflow-x: hidden;
       color: #333;
       position: relative;
@@ -25,7 +25,7 @@
       min-width: 80px;
       z-index: 5;
       pointer-events: none;
-      outline: 2px dashed rgba(0,0,0,0.2);
+      /* Removed guideline outline for cleaner look */
     }
 
     .left-lane {
@@ -39,7 +39,7 @@
       position: absolute;
       bottom: 0;
       border-radius: 50%;
-      background: rgba(255, 255, 255, 0.5);
+      background: rgba(255, 255, 255, 0.4);
       opacity: 0;
       animation: floatUp linear forwards;
       z-index: 6;
@@ -72,6 +72,7 @@
       justify-content: center;
       position: relative;
       z-index: 10;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     }
 
     header img.logo {
@@ -92,6 +93,7 @@
       justify-content: center;
       padding: 0.75em;
       z-index: 10;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     }
 
     nav a {
@@ -99,6 +101,7 @@
       margin: 0 1.5em;
       text-decoration: none;
       font-weight: 500;
+      transition: color 0.2s ease-in-out;
     }
 
     nav a:hover {
@@ -239,7 +242,6 @@
       const duration = 10 + Math.random() * 6;
       bubble.style.animationDuration = `${duration}s`;
 
-      console.log(`🫧 Bubble created in ${lane.id}, size: ${size}px, duration: ${duration}s`);
       lane.appendChild(bubble);
       setTimeout(() => bubble.remove(), duration * 1000);
     }


### PR DESCRIPTION
## Summary
- Refresh base styling with gradient background and polished header/navigation.
- Remove bubble column guideline outlines and extraneous debug logging.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f8877ec9c83308f35ac279c894ef9